### PR TITLE
Multiple parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ export default {
 | dataset   | Object | null                                                                      | nested tree data                                                                   |
 | config    | Object | {<br />nodeWidth: 100,<br />nodeHeight: 100,<br />levelHeight: 200<br />} | nodeWidth and nodeHeight config the tree node size. levelHeight is tree row height |
 | linkStyle | String | 'curve'                                                                   | control link style, options: 'curve' or 'straight'                                 |
-| direction | string | 'vertical'
+| direction | string | 'vertical' | control tree chart direction, options: 'vertical' or 'horizontal'                  |
 | collapse-enabled | Boolean | true | Control whether when clicking on a node it collapses its children |
 
 **4.2 slot**

--- a/README.md
+++ b/README.md
@@ -393,7 +393,8 @@ export default {
 | dataset   | Object | null                                                                      | nested tree data                                                                   |
 | config    | Object | {<br />nodeWidth: 100,<br />nodeHeight: 100,<br />levelHeight: 200<br />} | nodeWidth and nodeHeight config the tree node size. levelHeight is tree row height |
 | linkStyle | String | 'curve'                                                                   | control link style, options: 'curve' or 'straight'                                 |
-| direction | string | 'vertical'                                                                | control tree chart direction, options: 'vertical' or 'horizontal'                  |
+| direction | string | 'vertical'
+| collapse-enabled | Boolean | true | Control whether when clicking on a node it collapses its children |
 
 **4.2 slot**
 

--- a/README.md
+++ b/README.md
@@ -278,6 +278,112 @@ export default {
 
 ![](https://tva1.sinaimg.cn/large/007S8ZIlly1geprx8a8zgj30sh0hdglq.jpg)
 
+**3.4 render tree with multiple parents**
+
+<details>
+  <summary>See Code</summary>
+
+```vue
+<template>
+  <div class='container'>
+    <vue-tree
+      style="width: 800px; height: 600px; border: 1px solid gray;"
+      :dataset="vehicules"
+      :config="treeConfig"
+      linkStyle="straight"
+    >
+      <template v-slot:node="{ node, collapsed }">
+        <div
+          class="rich-media-node"
+          :style="{ border: collapsed ? '2px solid grey' : '' }"
+        >
+          <span style="padding: 4px 0; font-weight: bold;"
+          >能力值{{ node.name }}</span
+          >
+        </div>
+      </template>
+    </vue-tree>
+  </div>
+</template>
+<script>
+export default {
+  name: 'treemap',
+  data() {
+    return {
+      vehicules: {
+        name: 'Wheels',
+        children: [
+          {
+            name: 'Wings',
+            children: [
+              {
+                name: 'Plane'
+              }
+            ]
+          },
+          {
+            name: 'Piston',
+            customID: 3
+          },
+          {
+            name: 'Carburetor',
+            children: [
+              {
+                name: 'Truck',
+                customID: 2
+              },
+              {
+                name: 'Car',
+                customID: 2
+              }
+            ]
+          },
+          {
+            name: 'Valve',
+            customID: 4
+          },
+          {
+            name: 'Crankshaft',
+            customID: 1
+          }
+        ],
+        links: [
+          { parent: 1, child: 2 },
+          { parent: 3, child: 2 },
+          { parent: 4, child: 2 }
+        ],
+        identifier: 'customID'
+      },
+      treeConfig: { nodeWidth: 120, nodeHeight: 80, levelHeight: 200 }
+    }
+  }
+}
+</script>
+
+<style scoped lang="less">
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.rich-media-node {
+  width: 80px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  color: white;
+  background-color: #f7c616;
+  border-radius: 4px;
+}
+</style>
+```
+</details>
+
+![](https://github.com/Maxim-Durand/scrapcalculator/blob/143ef85f15aaca1b4044faa6fbfc920922aa5ec2/src/assets/multipleParents.png?raw=true)
+
 #### 4. API
 
 **4.1 props**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssthouse/vue-tree-chart",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/VueTreeDemo.vue
+++ b/src/components/VueTreeDemo.vue
@@ -124,7 +124,7 @@
     <h3>Example of multiple parents</h3>
     <vue-tree
       style="width: 800px; height: 600px; border: 1px solid gray;"
-      :dataset="tier3"
+      :dataset="vehicules"
       :config="treeConfig"
       linkStyle="straight"
     >
@@ -211,7 +211,7 @@ export default {
           }
         ]
       },
-      tier3: {
+      vehicules: {
         name: 'Wheels',
         children: [
           {

--- a/src/components/VueTreeDemo.vue
+++ b/src/components/VueTreeDemo.vue
@@ -121,11 +121,12 @@
       </template>
     </vue-tree>
 
-    <h3>Example of multiple parents</h3>
+    <h3>Example of multiple parents with node collapse disabled</h3>
     <vue-tree
       style="width: 800px; height: 600px; border: 1px solid gray;"
       :dataset="vehicules"
       :config="treeConfig"
+      :collapse-enabled="false"
       linkStyle="straight"
     >
       <template v-slot:node="{ node, collapsed }">
@@ -134,7 +135,7 @@
           :style="{ border: collapsed ? '2px solid grey' : '' }"
         >
           <span style="padding: 4px 0; font-weight: bold;"
-            >能力值{{ node.name }}</span
+            >能力值 {{ node.name }}</span
           >
         </div>
       </template>

--- a/src/components/VueTreeDemo.vue
+++ b/src/components/VueTreeDemo.vue
@@ -120,6 +120,25 @@
         </div>
       </template>
     </vue-tree>
+
+    <h3>Example of multiple parents</h3>
+    <vue-tree
+      style="width: 800px; height: 600px; border: 1px solid gray;"
+      :dataset="tier3"
+      :config="treeConfig"
+      linkStyle="straight"
+    >
+      <template v-slot:node="{ node, collapsed }">
+        <div
+          class="rich-media-node"
+          :style="{ border: collapsed ? '2px solid grey' : '' }"
+        >
+          <span style="padding: 4px 0; font-weight: bold;"
+            >能力值{{ node.name }}</span
+          >
+        </div>
+      </template>
+    </vue-tree>
   </div>
 </template>
 
@@ -191,6 +210,50 @@ export default {
               'https://live.yworks.com/demos/complete/interactiveorgchart/resources/usericon_female3.svg'
           }
         ]
+      },
+      tier3: {
+        name: 'Wheels',
+        children: [
+          {
+            name: 'Wings',
+            children: [
+              {
+                name: 'Plane'
+              }
+            ]
+          },
+          {
+            name: 'Piston',
+            customID: 3
+          },
+          {
+            name: 'Carburetor',
+            children: [
+              {
+                name: 'Truck',
+                customID: 2
+              },
+              {
+                name: 'Car',
+                customID: 2
+              }
+            ]
+          },
+          {
+            name: 'Valve',
+            customID: 4
+          },
+          {
+            name: 'Crankshaft',
+            customID: 1
+          }
+        ],
+        links: [
+          { parent: 1, child: 2 },
+          { parent: 3, child: 2 },
+          { parent: 4, child: 2 }
+        ],
+        identifier: 'customID'
       },
       treeConfig: { nodeWidth: 120, nodeHeight: 80, levelHeight: 200 }
     }

--- a/src/vue-tree/VueTree.vue
+++ b/src/vue-tree/VueTree.vue
@@ -100,6 +100,10 @@ export default {
       type: String,
       default: DIRECTION.VERTICAL
     },
+    collapseEnabled: {
+      type: Boolean,
+      default: true
+    },
     // 展示的层级数据, 样例数据如: hierachical.json
     dataset: {
       type: Object,
@@ -403,17 +407,19 @@ export default {
       }
     },
     onClickNode(index) {
-      const curNode = this.nodeDataList[index]
-      if (curNode.data.children) {
-        curNode.data._children = curNode.data.children
-        curNode.data.children = null
-        curNode.data._collapsed = true
-      } else {
-        curNode.data.children = curNode.data._children
-        curNode.data._children = null
-        curNode.data._collapsed = false
+      if (this.collapseEnabled) {
+        const curNode = this.nodeDataList[index]
+        if (curNode.data.children) {
+          curNode.data._children = curNode.data.children
+          curNode.data.children = null
+          curNode.data._collapsed = true
+        } else {
+          curNode.data.children = curNode.data._children
+          curNode.data._children = null
+          curNode.data._collapsed = false
+        }
+        this.draw()
       }
-      this.draw()
     },
     formatDimension(dimension) {
       if (typeof dimension === 'number') return `${dimension}px`

--- a/src/vue-tree/VueTree.vue
+++ b/src/vue-tree/VueTree.vue
@@ -281,12 +281,23 @@ export default {
       const specialLinks = this.dataset['links']
       if (specialLinks && identifier) {
         for (const link of specialLinks) {
-          const parent = this.nodeDataList.find((d) => {
-            return d[identifier] == link.parent
-          })
-          const children = this.nodeDataList.filter((d) => {
-            return d[identifier] == link.child
-          })
+          let parent,
+            children = undefined
+          if (identifier === 'value') {
+            parent = this.nodeDataList.find((d) => {
+              return d[identifier] == link.parent
+            })
+            children = this.nodeDataList.filter((d) => {
+              return d[identifier] == link.child
+            })
+          } else {
+            parent = this.nodeDataList.find((d) => {
+              return d['data'][identifier] == link.parent
+            })
+            children = this.nodeDataList.filter((d) => {
+              return d['data'][identifier] == link.child
+            })
+          }
           if (parent && children) {
             for (const child of children) {
               const new_link = {
@@ -294,22 +305,6 @@ export default {
                 target: child
               }
               this.linkDataList.push(new_link)
-            }
-          } else {
-            const parent = this.nodeDataList.find((d) => {
-              return d['data'][identifier] == link.parent
-            })
-            const children = this.nodeDataList.filter((d) => {
-              return d['data'][identifier] == link.child
-            })
-            if (parent && children) {
-              for (const child of children) {
-                const new_link = {
-                  source: parent,
-                  target: child
-                }
-                this.linkDataList.push(new_link)
-              }
             }
           }
         }

--- a/src/vue-tree/VueTree.vue
+++ b/src/vue-tree/VueTree.vue
@@ -271,6 +271,46 @@ export default {
     draw() {
       const [nodeDataList, linkDataList] = this.buildTree(this.dataset)
       this.linkDataList = linkDataList
+      this.nodeDataList = nodeDataList
+
+      const identifier = this.dataset['identifier']
+      const specialLinks = this.dataset['links']
+      if (specialLinks && identifier) {
+        for (const link of specialLinks) {
+          const parent = this.nodeDataList.find((d) => {
+            return d[identifier] == link.parent
+          })
+          const children = this.nodeDataList.filter((d) => {
+            return d[identifier] == link.child
+          })
+          if (parent && children) {
+            for (const child of children) {
+              const new_link = {
+                source: parent,
+                target: child
+              }
+              this.linkDataList.push(new_link)
+            }
+          } else {
+            const parent = this.nodeDataList.find((d) => {
+              return d['data'][identifier] == link.parent
+            })
+            const children = this.nodeDataList.filter((d) => {
+              return d['data'][identifier] == link.child
+            })
+            if (parent && children) {
+              for (const child of children) {
+                const new_link = {
+                  source: parent,
+                  target: child
+                }
+                this.linkDataList.push(new_link)
+              }
+            }
+          }
+        }
+      }
+
       this.svg = this.d3.select(this.$refs.svg)
 
       const self = this
@@ -304,8 +344,6 @@ export default {
         .ease(d3.easeCubicInOut)
         .style('opacity', 0)
         .remove()
-
-      this.nodeDataList = nodeDataList
     },
     buildTree(rootNode) {
       const treeBuilder = this.d3


### PR DESCRIPTION
In response to this issue: #31 

Added an array called 'links' to the root node, which contains new special links making it possible to create node with multiple parents. An example of a diagram is this: 

![](https://github.com/Maxim-Durand/scrapcalculator/blob/143ef85f15aaca1b4044faa6fbfc920922aa5ec2/src/assets/multipleParents.png?raw=true)

To make it easily customizable, I added an 'identifier' to know which nodes should have a special link.
I also added the option to disable node collapse.

This new feature was added to the VueTreeDemo.vue and README.md so that new users can easily understand how to use it.